### PR TITLE
fix nested DSL closure scope

### DIFF
--- a/src/main/groovy/javaposse/jobdsl/dsl/NodeDelegate.groovy
+++ b/src/main/groovy/javaposse/jobdsl/dsl/NodeDelegate.groovy
@@ -56,6 +56,7 @@ public class NodeDelegate {
             // block that wants to be configured
             def childClosure = args[0]
             childClosure.delegate = new NodeDelegate(targetNode)
+            childClosure.resolveStrategy = Closure.DELEGATE_FIRST
             childClosure.call(targetNode)
         } else {
             // Default to setting direct value

--- a/src/test/groovy/javaposse/jobdsl/dsl/NodeDelegateTest.groovy
+++ b/src/test/groovy/javaposse/jobdsl/dsl/NodeDelegateTest.groovy
@@ -4,11 +4,11 @@ import spock.lang.*
 import groovy.xml.MarkupBuilder
 
 class NodeDelegateTest extends Specification {
-    
+
     def "mutate config using configure block"() {
         setup:
         Node projectNode = new XmlParser().parse(new StringReader(minimalXml))
-        
+
         when: NodeDelegate nd = new NodeDelegate(projectNode)
         then: noExceptionThrown()
 
@@ -19,7 +19,25 @@ class NodeDelegateTest extends Specification {
         Node projectNode = new XmlParser().parse(new StringReader(minimalXml))
         NodeDelegate nd = new NodeDelegate(projectNode)
 
-        when: 
+        when:
+        nd.with { //configure block
+            builders {
+                'hudson.tasks.Ant' {
+                    name 'test'
+                }
+            }
+        }
+
+        then:
+        projectNode.builders.'hudson.tasks.Ant'.name.text() == 'test'
+    }
+
+    def "mutate nested node using configure block"() {
+        setup:
+        Node projectNode = new XmlParser().parse(new StringReader(minimalXml))
+        NodeDelegate nd = new NodeDelegate(projectNode)
+
+        when:
         nd.with { //configure block
             jdk ='JDK 6'
         }
@@ -56,7 +74,7 @@ class NodeDelegateTest extends Specification {
             description = 'Another description'
         }
     }
-    def minimalXml = 
+    def minimalXml =
 '''<project>
     <actions/>
     <description></description>


### PR DESCRIPTION
When using nested closure in the DSL, the node field of NodeDelegate was always the root project node.
For example :
job {
  ...
  configure { project ->
    builders {
      'hudson.tasks.Ant' {
        name 'test'
      }
    }
  }
}

resulted in the job configuration file into :
<job...>
  ...
  <builders />
  <hudson.tasks.Ant />
  <name>test</name>
</job>

instead of the expected result :
<job...>
  ...
  <builders>
    <hudson.tasks.Ant>
      <name>test</name>
    </hudson.tasks.Ant>
  </builders>
</job>
